### PR TITLE
fix: return relative paths from ReadDirectory instead of absolute

### DIFF
--- a/files/root.go
+++ b/files/root.go
@@ -94,11 +94,7 @@ func (f *Files) ReadDirectory(dirPath string) ([]string, error) {
 	var filePaths []string
 	for _, entry := range entries {
 		if !entry.IsDir() {
-			absPath, err := f.pr.Abs(f.pr.Join(dirPath, entry.Name()))
-			if err != nil {
-				return nil, fmt.Errorf("failed to get absolute path: %w", err)
-			}
-			filePaths = append(filePaths, absPath)
+			filePaths = append(filePaths, entry.Name())
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Changed ReadDirectory to return relative file paths instead of absolute paths
- Simplified the API by removing unnecessary absolute path conversion
- Makes the function behavior more predictable for callers

## Test plan
- [ ] Verify existing tests pass
- [ ] Test that ReadDirectory returns relative paths
- [ ] Ensure no regressions in code that uses ReadDirectory

🤖 Generated with [Claude Code](https://claude.ai/code)